### PR TITLE
Call build from prepare phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "rebuild": "rm -rf **/dist **/types && npm install",
     "test": "ts-mocha test/**/*.test.ts",
-    "build": "tsc -p ./tsconfig.json"
+    "build": "tsc -p ./tsconfig.json",
+    "prepare": "npm run build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
npm calls the "prepare" script automatically when it's preparing the tarball to submit. This ensures that `tsc` is called during the publish process :smile: